### PR TITLE
Add navigation header and creation forms

### DIFF
--- a/accounts/forms.py
+++ b/accounts/forms.py
@@ -1,0 +1,9 @@
+from django import forms
+
+from .models import AccountEntry
+
+
+class AccountEntryForm(forms.ModelForm):
+    class Meta:
+        model = AccountEntry
+        fields = ["description", "amount"]

--- a/accounts/urls.py
+++ b/accounts/urls.py
@@ -4,4 +4,5 @@ from . import views
 
 urlpatterns = [
     path("<int:client_id>/", views.client_entries, name="account-entries"),
+    path("<int:client_id>/add/", views.add_entry, name="account-entry-add"),
 ]

--- a/accounts/views.py
+++ b/accounts/views.py
@@ -1,8 +1,11 @@
-from django.shortcuts import get_object_or_404, render
+from django.contrib.auth.decorators import login_required
+from django.shortcuts import get_object_or_404, redirect, render
 
 from clients.models import Client
+from .forms import AccountEntryForm
 
 
+@login_required
 def client_entries(request, client_id):
     client = get_object_or_404(Client, id=client_id)
     entries = client.entries.all()
@@ -10,4 +13,23 @@ def client_entries(request, client_id):
         request,
         "accounts/entries.html",
         {"client": client, "entries": entries},
+    )
+
+
+@login_required
+def add_entry(request, client_id):
+    client = get_object_or_404(Client, id=client_id)
+    if request.method == "POST":
+        form = AccountEntryForm(request.POST)
+        if form.is_valid():
+            entry = form.save(commit=False)
+            entry.client = client
+            entry.save()
+            return redirect("account-entries", client_id=client.id)
+    else:
+        form = AccountEntryForm()
+    return render(
+        request,
+        "accounts/entry_form.html",
+        {"form": form, "client": client},
     )

--- a/clients/forms.py
+++ b/clients/forms.py
@@ -1,0 +1,9 @@
+from django import forms
+
+from .models import Client
+
+
+class ClientForm(forms.ModelForm):
+    class Meta:
+        model = Client
+        fields = ["name", "email", "tax_id", "address"]

--- a/clients/urls.py
+++ b/clients/urls.py
@@ -1,7 +1,8 @@
 from django.urls import path
 
-from .views import ClientListView
+from .views import ClientListView, ClientCreateView
 
 urlpatterns = [
     path("", ClientListView.as_view(), name="client-list"),
+    path("new/", ClientCreateView.as_view(), name="client-create"),
 ]

--- a/clients/views.py
+++ b/clients/views.py
@@ -1,9 +1,22 @@
 from django.contrib.auth.mixins import LoginRequiredMixin
-from django.views.generic import ListView
+from django.urls import reverse_lazy
+from django.views.generic import ListView, CreateView
 
+from .forms import ClientForm
 from .models import Client
 
 
 class ClientListView(LoginRequiredMixin, ListView):
     model = Client
     template_name = "clients/client_list.html"
+
+
+class ClientCreateView(LoginRequiredMixin, CreateView):
+    model = Client
+    form_class = ClientForm
+    template_name = "clients/client_form.html"
+    success_url = reverse_lazy("client-list")
+
+    def form_valid(self, form):
+        form.instance.owner = self.request.user
+        return super().form_valid(form)

--- a/core/urls.py
+++ b/core/urls.py
@@ -17,8 +17,10 @@ Including another URLconf
 
 from django.contrib import admin
 from django.urls import path, include
+from django.views.generic import RedirectView
 
 urlpatterns = [
+    path("", RedirectView.as_view(pattern_name="client-list", permanent=False)),
     path("admin/", admin.site.urls),
     path("clients/", include("clients.urls")),
     path("accounts/", include("accounts.urls")),

--- a/invoices/forms.py
+++ b/invoices/forms.py
@@ -1,0 +1,9 @@
+from django import forms
+
+from .models import Invoice
+
+
+class InvoiceForm(forms.ModelForm):
+    class Meta:
+        model = Invoice
+        fields = ["client", "number", "total"]

--- a/invoices/urls.py
+++ b/invoices/urls.py
@@ -1,7 +1,8 @@
 from django.urls import path
 
-from .views import InvoiceListView
+from .views import InvoiceListView, InvoiceCreateView
 
 urlpatterns = [
     path("", InvoiceListView.as_view(), name="invoice-list"),
+    path("new/", InvoiceCreateView.as_view(), name="invoice-create"),
 ]

--- a/invoices/views.py
+++ b/invoices/views.py
@@ -1,9 +1,18 @@
 from django.contrib.auth.mixins import LoginRequiredMixin
-from django.views.generic import ListView
+from django.urls import reverse_lazy
+from django.views.generic import ListView, CreateView
 
+from .forms import InvoiceForm
 from .models import Invoice
 
 
 class InvoiceListView(LoginRequiredMixin, ListView):
     model = Invoice
     template_name = "invoices/invoice_list.html"
+
+
+class InvoiceCreateView(LoginRequiredMixin, CreateView):
+    model = Invoice
+    form_class = InvoiceForm
+    template_name = "invoices/invoice_form.html"
+    success_url = reverse_lazy("invoice-list")

--- a/templates/accounts/entries.html
+++ b/templates/accounts/entries.html
@@ -1,6 +1,7 @@
 {% extends "base.html" %}
 {% block content %}
 <h1>Account for {{ client.name }}</h1>
+<p><a href="{% url 'account-entry-add' client.id %}">Add entry</a></p>
 <table>
 <tr><th>Date</th><th>Description</th><th>Amount</th><th>Balance</th></tr>
 {% for entry in entries %}

--- a/templates/accounts/entry_form.html
+++ b/templates/accounts/entry_form.html
@@ -1,0 +1,9 @@
+{% extends "base.html" %}
+{% block content %}
+<h1>New entry for {{ client.name }}</h1>
+<form method="post">
+  {% csrf_token %}
+  {{ form.as_p }}
+  <button type="submit">Save</button>
+</form>
+{% endblock %}

--- a/templates/base.html
+++ b/templates/base.html
@@ -5,6 +5,14 @@
   <title>Accounting System</title>
 </head>
 <body>
-  {% block content %}{% endblock %}
+  <header>
+    <nav>
+      <a href="{% url 'client-list' %}">Clients</a> |
+      <a href="{% url 'invoice-list' %}">Invoices</a>
+    </nav>
+  </header>
+  <main>
+    {% block content %}{% endblock %}
+  </main>
 </body>
 </html>

--- a/templates/clients/client_form.html
+++ b/templates/clients/client_form.html
@@ -1,0 +1,9 @@
+{% extends "base.html" %}
+{% block content %}
+<h1>New Client</h1>
+<form method="post">
+  {% csrf_token %}
+  {{ form.as_p }}
+  <button type="submit">Save</button>
+</form>
+{% endblock %}

--- a/templates/clients/client_list.html
+++ b/templates/clients/client_list.html
@@ -1,9 +1,10 @@
 {% extends "base.html" %}
 {% block content %}
 <h1>Clients</h1>
+<p><a href="{% url 'client-create' %}">Add client</a></p>
 <ul>
   {% for client in object_list %}
-  <li>{{ client.name }} - {{ client.tax_id }}</li>
+  <li><a href="{% url 'account-entries' client.id %}">{{ client.name }}</a> - {{ client.tax_id }}</li>
   {% empty %}
   <li>No clients.</li>
   {% endfor %}

--- a/templates/invoices/invoice_form.html
+++ b/templates/invoices/invoice_form.html
@@ -1,0 +1,9 @@
+{% extends "base.html" %}
+{% block content %}
+<h1>New Invoice</h1>
+<form method="post">
+  {% csrf_token %}
+  {{ form.as_p }}
+  <button type="submit">Save</button>
+</form>
+{% endblock %}

--- a/templates/invoices/invoice_list.html
+++ b/templates/invoices/invoice_list.html
@@ -1,6 +1,7 @@
 {% extends "base.html" %}
 {% block content %}
 <h1>Invoices</h1>
+<p><a href="{% url 'invoice-create' %}">Add invoice</a></p>
 <ul>
   {% for invoice in object_list %}
   <li>{{ invoice.number }} - {{ invoice.client.name }} - {{ invoice.total }}</li>


### PR DESCRIPTION
## Summary
- add header with navigation links
- provide forms and views to create clients, invoices, and account entries
- redirect root URL to client list for easier access

## Testing
- `python manage.py test`

------
https://chatgpt.com/codex/tasks/task_e_68bb198c2c7883209072e07729dd9bce