### PR TITLE
Agregar página de inicio de sesión accesible sin autenticación

### DIFF
--- a/core/settings.py
+++ b/core/settings.py
@@ -128,3 +128,7 @@ DEFAULT_AUTO_FIELD = "django.db.models.BigAutoField"
 AUTH_USER_MODEL = "users.User"
 
 EMAIL_BACKEND = "django.core.mail.backends.console.EmailBackend"
+
+LOGIN_URL = "login"
+LOGIN_REDIRECT_URL = "client-list"
+LOGOUT_REDIRECT_URL = "login"

--- a/core/urls.py
+++ b/core/urls.py
@@ -16,12 +16,15 @@ Including another URLconf
 """
 
 from django.contrib import admin
+from django.contrib.auth import views as auth_views
 from django.urls import path, include
 from django.views.generic import RedirectView
 
 urlpatterns = [
     path("", RedirectView.as_view(pattern_name="client-list", permanent=False)),
     path("admin/", admin.site.urls),
+    path("login/", auth_views.LoginView.as_view(template_name="registration/login.html"), name="login"),
+    path("logout/", auth_views.LogoutView.as_view(), name="logout"),
     path("clients/", include("clients.urls")),
     path("accounts/", include("accounts.urls")),
     path("invoices/", include("invoices.urls")),

--- a/templates/registration/login.html
+++ b/templates/registration/login.html
@@ -1,0 +1,39 @@
+{% extends "base.html" %}
+
+{% block content %}
+<div class="max-w-md mx-auto bg-white p-6 rounded-lg shadow-md">
+  <h1 class="text-2xl font-semibold text-gray-800 mb-4 text-center">Iniciar sesión</h1>
+  {% if form.non_field_errors %}
+    <div class="bg-red-100 text-red-700 p-3 rounded mb-4">
+      {% for error in form.non_field_errors %}
+        <p>{{ error }}</p>
+      {% endfor %}
+    </div>
+  {% endif %}
+  <form method="post" class="space-y-4">
+    {% csrf_token %}
+    <div>
+      <label for="id_username" class="block text-sm font-medium text-gray-700">Usuario</label>
+      <input type="text" name="username" id="id_username" value="{{ form.username.value }}" required autofocus
+             class="mt-1 block w-full rounded-md border-gray-300 shadow-sm focus:border-blue-500 focus:ring-blue-500" />
+      {% if form.username.errors %}
+        <p class="text-sm text-red-600 mt-1">{{ form.username.errors|join:", " }}</p>
+      {% endif %}
+    </div>
+    <div>
+      <label for="id_password" class="block text-sm font-medium text-gray-700">Contraseña</label>
+      <input type="password" name="password" id="id_password" required
+             class="mt-1 block w-full rounded-md border-gray-300 shadow-sm focus:border-blue-500 focus:ring-blue-500" />
+      {% if form.password.errors %}
+        <p class="text-sm text-red-600 mt-1">{{ form.password.errors|join:", " }}</p>
+      {% endif %}
+    </div>
+    <button
+      type="submit"
+      class="w-full py-2 px-4 bg-blue-600 text-white rounded-md hover:bg-blue-700 transition"
+    >
+      Ingresar
+    </button>
+  </form>
+</div>
+{% endblock %}


### PR DESCRIPTION
## Resumen
- definir rutas de inicio y cierre de sesión usando las vistas de Django
- configurar las URLs de autenticación en la configuración del proyecto para redirigir correctamente
- añadir plantilla estilizada para el formulario de inicio de sesión

## Pruebas
- python manage.py test

------
https://chatgpt.com/codex/tasks/task_e_68cd7122821883209e5df035a92920a2